### PR TITLE
Credentials feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ botserverrc
 # Pycharm
 \.DS_Store
 \.idea/
+
+# VSCode
+.vscode/

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -291,6 +291,10 @@ class MissingURLError(ZulipError):
 class UnrecoverableNetworkError(ZulipError):
     pass
 
+class InvalidCredentialsError(ZulipError):
+    pass
+
+
 class Client:
     def __init__(self, email: Optional[str] = None, api_key: Optional[str] = None, config_file: Optional[str] = None,
                  verbose: bool = False, retry_on_errors: bool = True,
@@ -419,6 +423,9 @@ class Client:
         self.session = None  # type: Optional[requests.Session]
 
         self.has_connected = False
+        
+        if self.get_profile()["result"] == "error":
+            raise InvalidCredentialsError("Invalid API Credentials")
 
     def ensure_session(self) -> None:
 

--- a/zulip/zulip/send.py
+++ b/zulip/zulip/send.py
@@ -71,8 +71,10 @@ def main() -> int:
     if len(options.recipients) == 0 and not (options.stream and options.subject):
         parser.error('You must specify a stream/subject or at least one recipient.')
 
-    client = zulip.init_from_options(options)
-
+    try:
+        client = zulip.init_from_options(options)
+    except zulip.InvalidCredentialsError:
+        return 1
     if not options.message:
         options.message = sys.stdin.read()
 

--- a/zulip/zulip/send.py
+++ b/zulip/zulip/send.py
@@ -74,6 +74,7 @@ def main() -> int:
     try:
         client = zulip.init_from_options(options)
     except zulip.InvalidCredentialsError:
+        log.exception("Invalid API credentials")
         return 1
     if not options.message:
         options.message = sys.stdin.read()


### PR DESCRIPTION
issue#533 : api: Give quicker feedback if your credentials are wrong
Changes in __init__ method of the client to throw an error if the credentials are incorrect.